### PR TITLE
checkin Project.toml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,9 @@ jobs:
       with:
         version: 1.5
     - run: julia -e '
-            using Pkg; Pkg.add(["NodeJS", "Franklin", "BibTeX"]);
+            using Pkg; Pkg.activate("."); Pkg.instantiate();
             using NodeJS; run(`$(npm_cmd()) install highlight.js`);
             using Franklin;
-            Pkg.activate("."); Pkg.instantiate();
             optimize()'
     - name: Build and Deploy
       uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+BibTeX = "7b0aa2c9-049f-5cec-894a-2b6b781bb25e"
+Franklin = "713c75ef-9fc9-4b05-94a9-213340da978e"
+NodeJS = "2bd173c7-0d6d-553b-b6af-13a54713934c"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ JuliaLab Website. Edit this to edit the website.
 - "People" section: `_assets/people.csv` and `_assets/people` (pay attention to the name format)
 
 ### Notes about deploy
-- Changes applied to the master branch will be automatically deployed to the gh-pages branch.
-- If you add a new dependency, remember to add it also in `.github/workflows/deploy.yml`.
+- You can serve the webpage locally by:
+  > `$ julia --project=@.`
+  ```julia
+  julia> using Pkg; Pkg.instantiate()
 
+  julia> using Franklin; Franklin.serve()
+  ```
+- Changes applied to the `master` branch will be automatically deployed to the `gh-pages` branch.
+- If you add a new dependency, remember to add it also in `Project.toml`.


### PR DESCRIPTION
It would let us easily serve the webpage locally if we check-in the
Project.toml file and allow instantiating the serve environment from it.