### PR TITLE
Swap homepage videos to 2023 SciML talks

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@
 ~~~
 <section class="videos">
 <iframe src="https://www.youtube.com/embed/qGW0GT1rCvs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<iframe src="https://www.youtube.com/embed/tQpqsmwlfY0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<iframe src="https://www.youtube.com/embed/XRJ-rtP2fVE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/tynmTkpdAME" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/16jtJDiJIuU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </section>
 ~~~


### PR DESCRIPTION
## Summary

Keeps Alan Edelman's TEDxMIT talk and swaps the two other (2020-2021 era) homepage embeds for two recent SciML talks from Chris's CV.

**Please ignore until reviewed by @ChrisRackauckas.**

### Final state

| Position | Video | Speaker |
| --- | --- | --- |
| 1 | A programming language to heal the planet together: Julia (TEDxMIT) | Alan Edelman |
| 2 | JuliaCon 2023 keynote — Scientific Machine Learning through Symbolic Numerics | Chris Rackauckas |
| 3 | LLNL DDPS Seminar — Generalizing SciML and Differentiable Simulation Beyond Continuous Models | Chris Rackauckas |

### Removed

- Jonathan Diegelman, "Modeling Spacecraft Separation Dynamics in Julia" (was 2nd slot)
- Chris Rackauckas, "The Julia SciML Ecosystem" (SIAM CSE 2021, was 3rd slot)

## Test plan

- [ ] Build site locally and confirm all three iframes render
- [ ] Confirm the Chris talks selected are the right pair; happy to swap the LLNL DDPS for ICIAM 2023 (5jat8moluUM) if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)